### PR TITLE
Add LCS and Levenshtein-Damerau measures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 authors = ["Daniël de Kok <me@danieldk.eu>"]
 
 [dependencies]
+
+[dev-dependencies]
+lazy_static = "1.0"

--- a/src/dynprog.rs
+++ b/src/dynprog.rs
@@ -1,5 +1,5 @@
-use {IndexedOperation, Measure, Operation, SeqPair};
-use op::{Backtrack, BestOperation};
+use {Measure, SeqPair};
+use op::{Backtrack, BestOperation, IndexedOperation, Operation};
 
 /// Edit distance cost matrix.
 pub struct CostMatrix<'a, M, T>
@@ -106,7 +106,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use IndexedOperation;
+    use op::IndexedOperation;
     use measures::Levenshtein;
     use measures::LevenshteinOp::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,12 @@ pub use dynprog::CostMatrix;
 
 pub mod measures;
 
-mod op;
-pub use op::{IndexedOperation, Operation};
+pub mod op;
 
 /// Trait for edit distance measures.
 pub trait Measure<T> {
     /// The edit operations associated with the measure.
-    type Operation: Operation<T>;
+    type Operation: op::Operation<T>;
 
     /// Get a slice with the measure's operations. Typically, this contains
     /// all the enum variants of the associated type `Operation`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#[cfg(test)]
+#[macro_use]
+extern crate lazy_static;
+
 mod dynprog;
 pub use dynprog::CostMatrix;
 

--- a/src/measures.rs
+++ b/src/measures.rs
@@ -101,3 +101,138 @@ where
         }
     }
 }
+
+/// Longest common subsequence (LCS) alignment.
+///
+/// This measure uses the following edit operations:
+///
+/// * Insert
+/// * Delete
+/// * Match
+///
+/// The matches in edit script for this measure give a longest common
+/// subsequence. The cost is the number of insertions/deletions after
+/// aligning the LCSes.
+#[derive(Clone, Debug)]
+pub struct LCS {
+    ops: [LCSOp; 3],
+}
+
+/// Construct LCS measure with the associated insertion and deletion
+/// cost.
+impl LCS {
+    pub fn new(insert_cost: usize, delete_cost: usize) -> Self {
+        use self::LCSOp::*;
+
+        LCS {
+            ops: [Insert(insert_cost), Delete(delete_cost), Match],
+        }
+    }
+}
+
+impl<T> Measure<T> for LCS
+where
+    T: Eq,
+{
+    type Operation = LCSOp;
+
+    fn operations(&self) -> &[Self::Operation] {
+        &self.ops
+    }
+}
+
+/// Levenshtein operation with associated cost.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum LCSOp {
+    Insert(usize),
+    Delete(usize),
+    Match,
+}
+
+impl<T> Operation<T> for LCSOp
+where
+    T: Eq,
+{
+    fn backtrack(
+        &self,
+        seq_pair: &SeqPair<T>,
+        source_idx: usize,
+        target_idx: usize,
+    ) -> Option<(usize, usize)> {
+        use self::LCSOp::*;
+
+        match *self {
+            Delete(cost) => archetype::Delete(cost).backtrack(seq_pair, source_idx, target_idx),
+            Insert(cost) => archetype::Insert(cost).backtrack(seq_pair, source_idx, target_idx),
+            Match => archetype::Match.backtrack(seq_pair, source_idx, target_idx),
+        }
+    }
+
+    fn cost(
+        &self,
+        seq_pair: &SeqPair<T>,
+        cost_matrix: &Vec<Vec<usize>>,
+        source_idx: usize,
+        target_idx: usize,
+    ) -> Option<usize> {
+        use self::LCSOp::*;
+
+        match *self {
+            Delete(cost) => {
+                archetype::Delete(cost).cost(seq_pair, cost_matrix, source_idx, target_idx)
+            }
+            Insert(cost) => {
+                archetype::Insert(cost).cost(seq_pair, cost_matrix, source_idx, target_idx)
+            }
+            Match => archetype::Match.cost(seq_pair, cost_matrix, source_idx, target_idx),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use Measure;
+    use measures::{Levenshtein, LCS};
+
+    use CostMatrix;
+
+    struct TestCase(&'static str, &'static str, usize, usize);
+
+    lazy_static! {
+        static ref TESTCASES: Vec<TestCase> = vec![
+            TestCase("pineapple", "", 9, 9),
+            TestCase("", "pineapple", 9, 9),
+            TestCase("pineapple", "pen", 7, 8),
+            TestCase("pen", "pineapple", 7, 8),
+            TestCase("pineapple", "applet", 5, 5),
+            TestCase("applet", "pen", 4, 5),
+        ];
+    }
+
+    #[test]
+    pub fn test_lcs() {
+        run_testcases(|| LCS::new(1, 1), |testcase| testcase.3);
+    }
+
+    #[test]
+    pub fn test_levenshtein() {
+        run_testcases(|| Levenshtein::new(1, 1, 1), |testcase| testcase.2);
+    }
+
+    fn run_testcases<MF, M, DF>(measure: MF, distance: DF)
+    where
+        MF: Fn() -> M,
+        M: Measure<char>,
+        DF: Fn(&TestCase) -> usize,
+    {
+        for testcase in TESTCASES.iter() {
+            let source: Vec<char> = testcase.0.chars().collect();
+            let target: Vec<char> = testcase.1.chars().collect();
+            assert_eq!(
+                distance(testcase),
+                CostMatrix::align(measure(), &source, &target).distance()
+            )
+        }
+    }
+
+}

--- a/src/op/archetype.rs
+++ b/src/op/archetype.rs
@@ -105,6 +105,7 @@ impl<T> Operation<T> for Match {
     {
         let (from_source_idx, from_target_idx) = self.backtrack(seq_pair, source_idx, target_idx)?;
         let orig_cost = cost_matrix[from_source_idx][from_target_idx];
+
         if seq_pair.source[from_source_idx] == seq_pair.target[from_target_idx] {
             Some(orig_cost)
         } else {
@@ -144,5 +145,46 @@ impl<T> Operation<T> for Substitute {
         let (from_source_idx, from_target_idx) = self.backtrack(seq_pair, source_idx, target_idx)?;
         let orig_cost = cost_matrix[from_source_idx][from_target_idx];
         Some(orig_cost + self.0)
+    }
+}
+
+/// Transpose operation with associated cost.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Transpose(pub usize);
+
+impl<T> Operation<T> for Transpose {
+    fn backtrack(
+        &self,
+        _seq_pair: &SeqPair<T>,
+        source_idx: usize,
+        target_idx: usize,
+    ) -> Option<(usize, usize)> {
+        if source_idx > 1 && target_idx > 1 {
+            Some((source_idx - 2, target_idx - 2))
+        } else {
+            None
+        }
+    }
+
+    fn cost(
+        &self,
+        seq_pair: &SeqPair<T>,
+        cost_matrix: &Vec<Vec<usize>>,
+        source_idx: usize,
+        target_idx: usize,
+    ) -> Option<usize>
+    where
+        T: Eq,
+    {
+        let (from_source_idx, from_target_idx) = self.backtrack(seq_pair, source_idx, target_idx)?;
+        let orig_cost = cost_matrix[from_source_idx][from_target_idx];
+
+        if seq_pair.source[from_source_idx] == seq_pair.target[from_target_idx + 1]
+            && seq_pair.source[from_source_idx + 1] == seq_pair.target[from_target_idx]
+        {
+            Some(orig_cost + self.0)
+        } else {
+            None
+        }
     }
 }

--- a/src/op/archetype.rs
+++ b/src/op/archetype.rs
@@ -1,0 +1,148 @@
+//! Archetypal edit operations.
+//!
+//! This module provides archetypal edit operations. These operations are
+//! not meant to be used directly, but can be used in the implementation
+//! of new measures.
+
+use op::Operation;
+use SeqPair;
+
+/// Delete operation with associated cost.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Delete(pub usize);
+
+impl<T> Operation<T> for Delete {
+    fn backtrack(
+        &self,
+        _seq_pair: &SeqPair<T>,
+        source_idx: usize,
+        target_idx: usize,
+    ) -> Option<(usize, usize)> {
+        if source_idx > 0 {
+            Some((source_idx - 1, target_idx))
+        } else {
+            None
+        }
+    }
+
+    fn cost(
+        &self,
+        seq_pair: &SeqPair<T>,
+        cost_matrix: &Vec<Vec<usize>>,
+        source_idx: usize,
+        target_idx: usize,
+    ) -> Option<usize>
+    where
+        T: Eq,
+    {
+        let (from_source_idx, from_target_idx) = self.backtrack(seq_pair, source_idx, target_idx)?;
+        let orig_cost = cost_matrix[from_source_idx][from_target_idx];
+        Some(orig_cost + self.0)
+    }
+}
+
+/// Insert operation with associated cost.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Insert(pub usize);
+
+impl<T> Operation<T> for Insert {
+    fn backtrack(
+        &self,
+        _seq_pair: &SeqPair<T>,
+        source_idx: usize,
+        target_idx: usize,
+    ) -> Option<(usize, usize)> {
+        if target_idx > 0 {
+            Some((source_idx, target_idx - 1))
+        } else {
+            None
+        }
+    }
+
+    fn cost(
+        &self,
+        seq_pair: &SeqPair<T>,
+        cost_matrix: &Vec<Vec<usize>>,
+        source_idx: usize,
+        target_idx: usize,
+    ) -> Option<usize>
+    where
+        T: Eq,
+    {
+        let (from_source_idx, from_target_idx) = self.backtrack(seq_pair, source_idx, target_idx)?;
+        let orig_cost = cost_matrix[from_source_idx][from_target_idx];
+        Some(orig_cost + self.0)
+    }
+}
+
+/// Match operation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Match;
+
+impl<T> Operation<T> for Match {
+    fn backtrack(
+        &self,
+        _seq_pair: &SeqPair<T>,
+        source_idx: usize,
+        target_idx: usize,
+    ) -> Option<(usize, usize)> {
+        if source_idx > 0 && target_idx > 0 {
+            Some((source_idx - 1, target_idx - 1))
+        } else {
+            None
+        }
+    }
+
+    fn cost(
+        &self,
+        seq_pair: &SeqPair<T>,
+        cost_matrix: &Vec<Vec<usize>>,
+        source_idx: usize,
+        target_idx: usize,
+    ) -> Option<usize>
+    where
+        T: Eq,
+    {
+        let (from_source_idx, from_target_idx) = self.backtrack(seq_pair, source_idx, target_idx)?;
+        let orig_cost = cost_matrix[from_source_idx][from_target_idx];
+        if seq_pair.source[from_source_idx] == seq_pair.target[from_target_idx] {
+            Some(orig_cost)
+        } else {
+            None
+        }
+    }
+}
+
+/// Substitute operation with associated cost.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Substitute(pub usize);
+
+impl<T> Operation<T> for Substitute {
+    fn backtrack(
+        &self,
+        _seq_pair: &SeqPair<T>,
+        source_idx: usize,
+        target_idx: usize,
+    ) -> Option<(usize, usize)> {
+        if source_idx > 0 && target_idx > 0 {
+            Some((source_idx - 1, target_idx - 1))
+        } else {
+            None
+        }
+    }
+
+    fn cost(
+        &self,
+        seq_pair: &SeqPair<T>,
+        cost_matrix: &Vec<Vec<usize>>,
+        source_idx: usize,
+        target_idx: usize,
+    ) -> Option<usize>
+    where
+        T: Eq,
+    {
+        let (from_source_idx, from_target_idx) = self.backtrack(seq_pair, source_idx, target_idx)?;
+        let orig_cost = cost_matrix[from_source_idx][from_target_idx];
+        Some(orig_cost + self.0)
+    }
+}

--- a/src/op/archetype.rs
+++ b/src/op/archetype.rs
@@ -159,7 +159,7 @@ impl<T> Operation<T> for Transpose {
         source_idx: usize,
         target_idx: usize,
     ) -> Option<(usize, usize)> {
-        if source_idx > 1 && target_idx > 1 {
+        if source_idx >= 2 && target_idx >= 2 {
             Some((source_idx - 2, target_idx - 2))
         } else {
             None

--- a/src/op/mod.rs
+++ b/src/op/mod.rs
@@ -1,6 +1,10 @@
+//! Edit operations.
+
 use std::fmt::Debug;
 
 use {Measure, SeqPair};
+
+pub mod archetype;
 
 /// Trait for sequence edit operations.
 pub trait Operation<T>: Clone + Debug + Eq {


### PR DESCRIPTION
This pull-request adds two distance measures:

* Longest common subsequence (actually the number of insertions/deletions required after constructing an LCS alignment).
* Levenstein-Damerau.

To keep things DRY, I have also factored out archetypical operations. This is the last pull request that needs to be integrated in order for me to continue with lemmatization.

I have some smaller aesthetic changes (such as renaming CostMatrix to Alignment), but I'll directly merge those to master without pull requests.